### PR TITLE
Bugfix/flow 11052 radios do not play

### DIFF
--- a/src/frontend/src/logging/loggers.ts
+++ b/src/frontend/src/logging/loggers.ts
@@ -147,3 +147,7 @@ export const {
   getLevel,
   getSeverity,
 } = new RootLogger()
+
+export type {
+  ILogger
+}

--- a/src/frontend/src/players/ipcStreamer.ts
+++ b/src/frontend/src/players/ipcStreamer.ts
@@ -1,103 +1,35 @@
-import { CircularBuffer } from '@taktik/buffers'
 import { IOutputTrack, TrackInfo } from '@taktik/mux.js'
 import { Writable } from 'stream'
 import { WebContents } from 'electron'
-import { IStreamerConfig } from '../interfaces/ipcStreamerConfig'
 import { getLogger } from '../logging/loggers'
-import { IOutputParser } from './parsers/types'
-import SimpleParser from './parsers/simple'
+import { OutputParserResponse } from './parsers/types'
 
 export class IpcStreamer extends Writable {
   private _sender: WebContents | undefined
-  private buffer: CircularBuffer
-  private sendInterval: number | undefined
   private log = getLogger('Ipc streamer')
-  private initSegment?: Buffer
 
   currentAudioPid: number | undefined
   currentTrackInfo: TrackInfo | undefined
   currentCodec = 'avc1.64001f, mp4a.40.5' // default codec: custom chromium always goes through ffmepg anyway
-  outputParser: IOutputParser = new SimpleParser()
 
   set sender(sender: WebContents | undefined) {
     this._sender = sender
   }
 
-  constructor({ capacity, maxCapacity, readMode }: IStreamerConfig) {
-    super({ autoDestroy: false })
-    this.buffer = new CircularBuffer({
-      allowOverwrite: false,
-      capacity,
-      maxCapacity,
-      readMode,
-    })
+  constructor() {
+    super({ autoDestroy: false, objectMode: true })
   }
 
-  // tslint:disable-next-line: function-name
-  _write(chunk: Buffer, encoding: BufferEncoding, callback: (error: Error | null | undefined) => void): void {
-    try {
-      const { initSegment, data, canSend } = this.outputParser.parse(chunk)
-      
-      this.initSegment = initSegment
-
-      if (canSend) {
-        this.attemptSend()
-      }
-
-      try {
-        this.buffer.write(data)
-      } catch (e) {
-        this.log.warn('Could not write chunk to streamer buffer:', e)
-        this.attemptSend()
-
-        try {
-          this.buffer.write(data)
-        } catch (error) {
-          this.log.error('Output chunk size is bigger than streamer\'s capacity. Consider increasing streamer\'s maxCapacity and/or capacity', error)
-          this.sendSegment(data)
-        }
-      }
-      callback(null)
-    } catch (e) {
-      callback(e)
-    }
-  }
-
-  clear(flush = false): void {
-    if (flush) {
-      this.attemptSend()
-    }
-    clearInterval(this.sendInterval)
-    this.buffer.clear()
-    this.sendInterval = undefined
-    this.removeAllListeners()
-    this.currentTrackInfo = undefined
-    this.initSegment = undefined
-    this.log.debug('Cleared')
-  }
-
-  // tslint:disable-next-line: function-name
-  _final(cb: (error?: Error) => void): void {
-    this.clear()
-    cb()
-  }
-
-  private formatFfmpegOutput(data: Buffer): IOutputTrack<'audio' | 'video'> {
+  private formatOutput({ initSegment, data }: OutputParserResponse): IOutputTrack<'audio' | 'video'> {
     const type = !this.currentTrackInfo?.video ? 'audio' : 'video' // default to video
     const pid = this.currentAudioPid || 0
 
     return {
       data,
       type,
-      initSegment: this.initSegment,
+      initSegment,
       codec: this.currentCodec,
       pid,
-    }
-  }
-
-  private attemptSend() {
-    if (this.buffer.availableRead) {
-      this.sendSegment(this.buffer.readAll())
     }
   }
 
@@ -105,13 +37,36 @@ export class IpcStreamer extends Writable {
     if (this._sender) {
       this._sender.send(message, content)
     } else {
-      this.log.error(`No sender defined, cannot send "${message}" message`)
+      this.log.warn(`No sender defined, cannot send "${message}" message`)
     }
   }
 
-  private sendSegment(segment: Buffer) {
-    const data = this.formatFfmpegOutput(segment)
-    this.send('segment', data)
+  private sendSegment(data: OutputParserResponse) {
+    const formatted = this.formatOutput(data)
+
+    this.send('segment', formatted)
+  }
+
+  // tslint:disable-next-line: function-name
+  _write(segment: OutputParserResponse, encoding: BufferEncoding, callback: (error: Error | null | undefined) => void): void {
+    try {
+      this.sendSegment(segment)
+      callback(null)
+    } catch (e) {
+      callback(e)
+    }
+  }
+
+  clear(): void {-
+    this.removeAllListeners()
+    this.currentTrackInfo = undefined
+    this.log.debug('Cleared')
+  }
+
+  // tslint:disable-next-line: function-name
+  _final(cb: (error?: Error) => void): void {
+    this.clear()
+    cb()
   }
 
   sendTrackInfo(trackInfo: TrackInfo): void {

--- a/src/frontend/src/players/parsers/abstract.ts
+++ b/src/frontend/src/players/parsers/abstract.ts
@@ -1,0 +1,113 @@
+import { CircularBuffer } from '@taktik/buffers'
+import { Transform, TransformCallback } from 'stream'
+import { IStreamerConfig } from '../../interfaces/ipcStreamerConfig'
+import { ILogger } from '../../logging/loggers'
+import { OutputParserResponse } from './types'
+
+/**
+ * Ffmpeg outputs can be handled differently depending on the used container format
+ * For example, we know how to structure mp4 chunks for them to be well handled by a MediaSource
+ * This transform stream is used as a buffer to structure this data and send it when we deem it readable
+ */
+abstract class FfmpegParser extends Transform {
+  private _buffer: CircularBuffer
+
+  protected abstract log: ILogger
+
+  constructor({ capacity, maxCapacity, readMode }: IStreamerConfig) {
+    super({ readableObjectMode: true })
+
+    this._buffer = new CircularBuffer({
+      allowOverwrite: false,
+      capacity,
+      maxCapacity,
+      readMode,
+    })
+  }
+
+  /**
+   * Format buffered data to a structure usable by a MediaSource
+   * @param {Buffer} bufferedData 
+   * @returns {OutputParserResponse} an optional init segment, and stream data
+   */
+  protected formatOutput(bufferedData: Buffer): OutputParserResponse {
+    return { data: bufferedData }
+  }
+
+  /**
+   * Read from buffer and push data to the next stream
+   */
+  protected attemptSend(): void {
+    const toRead = this._buffer.availableRead
+
+    if (toRead) {
+      if (!this.push(this.formatOutput(this._buffer.read(toRead)))) {
+        this._buffer.rewind(toRead)
+      }
+    }
+  }
+
+  /**
+   * Handle incoming data, optionnaly parse and reformat it
+   * Base implementation, aims to be overridden
+   * @param {Buffer} chunk Data to process
+   * @returns Data to be added to the inner buffer
+   */
+  protected preBufferProcess(chunk: Buffer): Buffer {
+    return chunk
+  }
+
+  /**
+   * Append data to the inner buffer
+   * If data fails to be appended, attempt to free some data
+   * If append still fails, directly send it
+   * @param {Buffer} chunk Data to add to the buffer
+   */
+  protected buffer(chunk: Buffer): void {
+    try {
+      this._buffer.write(chunk)
+    } catch (e) {
+      this.log.warn('Could not write chunk to streamer buffer:', e)
+      this.attemptSend()
+
+      try {
+        this._buffer.write(chunk)
+      } catch (error) {
+        this.log.error('Output chunk size is bigger than streamer\'s capacity. Consider increasing streamer\'s maxCapacity and/or capacity', error)
+        this.write(chunk)
+      }
+    }
+  }
+
+  /**
+   * Start any action after data has been added to the buffer
+   * Base implementation, aims to be overridden
+   */
+  protected postBufferProcess(): void {
+    // Empty base implementation
+  }
+
+  _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {
+    try {
+      const data = this.preBufferProcess(chunk)
+
+      this.buffer(data)
+
+      this.postBufferProcess()
+      callback(null)
+    } catch (error) {
+      callback(error)
+    }
+  }
+
+  clear(flush = false): void {
+    if (flush) {
+      this.attemptSend()
+    }
+    this._buffer.clear()
+    this.removeAllListeners()
+    this.log.debug('Cleared')
+  }
+}
+
+export default FfmpegParser

--- a/src/frontend/src/players/parsers/abstract.ts
+++ b/src/frontend/src/players/parsers/abstract.ts
@@ -35,13 +35,22 @@ abstract class FfmpegParser extends Transform {
   }
 
   /**
-   * Read from buffer and push data to the next stream
+   * Actually push formatted data buffer
+   * @param {Buffer} buffer 
+   * @returns {Boolean} Whether the push operation was successful
+   */
+  private send(buffer: Buffer): boolean {
+    return this.push(this.formatOutput(buffer))
+  }
+
+  /**
+   * Read from buffer and attempt to push data to the next stream
    */
   protected attemptSend(): void {
     const toRead = this._buffer.availableRead
 
     if (toRead) {
-      if (!this.push(this.formatOutput(this._buffer.read(toRead)))) {
+      if (!this.send(this._buffer.read(toRead))) {
         this._buffer.rewind(toRead)
       }
     }
@@ -74,7 +83,7 @@ abstract class FfmpegParser extends Transform {
         this._buffer.write(chunk)
       } catch (error) {
         this.log.error('Output chunk size is bigger than streamer\'s capacity. Consider increasing streamer\'s maxCapacity and/or capacity', error)
-        this.write(chunk)
+        this.send(chunk)
       }
     }
   }

--- a/src/frontend/src/players/parsers/mp4.ts
+++ b/src/frontend/src/players/parsers/mp4.ts
@@ -15,7 +15,7 @@ class Mp4Parser extends FfmpegParser {
   /**
    * From a chunk of data, attempt to find a "moof" box
    * This box type announces the beginning of a new data segment
-   * This allows to structure forwarded data to somehthing that can be handled easily
+   * This allows to structure forwarded data to something that can be handled easily
    * @param chunk 
    * @returns Data to be added to the inner buffer; and whether a segment has been completed
    */

--- a/src/frontend/src/players/parsers/mp4.ts
+++ b/src/frontend/src/players/parsers/mp4.ts
@@ -1,0 +1,56 @@
+import { mp4 } from '@taktik/mux.js'
+import { getLogger } from '../../logging/loggers'
+import { IOutputParser, OutputParserResponse } from './types'
+
+class Mp4Parser implements IOutputParser {
+  private log = getLogger('mp4 parser')
+  private initSegment?: Buffer
+  private initSegmentComplete = false
+
+  private appendToInitSegment(chunk: Buffer): void {
+    this.initSegment = this.initSegment ? Buffer.concat([this.initSegment, chunk]) : chunk
+  }
+
+  parse(chunk: Buffer): OutputParserResponse {
+    let data = chunk
+
+    // Attempt to find a "moof" box in the chunk
+    // if it is found, it means we reached the end of the previous box's data
+    const [moof] = mp4.tools.findBox(chunk, ['moof'])
+
+    if (!this.initSegmentComplete && moof) {
+      // receiving a "moof" means that the initialization segment is complete
+      this.initSegmentComplete = true
+
+      /**
+       * The call to "findBox" above returns the requested boxes' content if found, without their header
+       * The header is composed of 8 bytes: 4 bytes for the boxe's size (in bytes) + 4 bytes for its type (e.g moof, mdat, ftyp, etc...)
+       * Thus the "index - 8" below: we want to retrieve the index of the beginning of the whole box, headers included
+       */
+      const indexBeforeHeaders = chunk.indexOf(moof) - 8
+
+      if (indexBeforeHeaders < 0) {
+        this.log.warn('Something is wrong, we detected the first moof box but there is not enough room for its headers ?!')
+      } else if (indexBeforeHeaders > 0) {
+        this.log.info(`Found first moof at index ${indexBeforeHeaders} in the chunk. Attempt to complete init segment.`)
+        this.appendToInitSegment(chunk.slice(0, indexBeforeHeaders))
+        data = chunk.slice(indexBeforeHeaders)
+      } else {
+        // "moof" is at the start of the package, no need to do anything else
+      }
+    }
+
+    if (!this.initSegmentComplete) {
+      this.log.debug('Completing init segment')
+      this.appendToInitSegment(chunk)
+    }
+
+    return {
+      initSegment: this.initSegmentComplete ? this.initSegment : undefined,
+      data,
+      canSend: this.initSegmentComplete && !!moof,
+    }
+  }
+}
+
+export default Mp4Parser

--- a/src/frontend/src/players/parsers/simple.ts
+++ b/src/frontend/src/players/parsers/simple.ts
@@ -1,0 +1,13 @@
+import { IOutputParser, OutputParserResponse } from './types'
+
+class SimpleParser implements IOutputParser {
+  parse(chunk: Buffer): OutputParserResponse {
+    return {
+      initSegment: undefined,
+      data: chunk,
+      canSend: true,
+    }
+  }
+}
+
+export default SimpleParser

--- a/src/frontend/src/players/parsers/simple.ts
+++ b/src/frontend/src/players/parsers/simple.ts
@@ -1,12 +1,31 @@
-import { IOutputParser, OutputParserResponse } from './types'
+import { IStreamerConfig } from '../../interfaces/ipcStreamerConfig'
+import { getLogger } from '../../logging/loggers'
+import FfmpegParser from './abstract'
 
-class SimpleParser implements IOutputParser {
-  parse(chunk: Buffer): OutputParserResponse {
-    return {
-      initSegment: undefined,
-      data: chunk,
-      canSend: true,
+class SimpleParser extends FfmpegParser {
+  protected log = getLogger('simple parser')
+  private sendInterval: NodeJS.Timer | undefined
+  private sendIntervalValue: number
+
+  constructor(config: IStreamerConfig) {
+    super(config)
+
+    this.sendIntervalValue = config.sendInterval
+  }
+
+  /**
+   * Start sending data at a specific time interval
+   */
+  protected postBufferProcess(): void {
+    if (!this.sendInterval) {
+      this.sendInterval = setInterval(this.attemptSend.bind(this), this.sendIntervalValue)
     }
+  }
+
+  clear(flush: boolean): void {
+    clearInterval(this.sendInterval)
+    this.sendInterval = undefined
+    super.clear(flush)
   }
 }
 

--- a/src/frontend/src/players/parsers/types.ts
+++ b/src/frontend/src/players/parsers/types.ts
@@ -3,11 +3,6 @@ type OutputParserResponse = {
   data: Buffer
 }
 
-interface IOutputParser {
-  parse(chunk: Buffer): OutputParserResponse
-}
-
 export {
-  IOutputParser,
   OutputParserResponse,
 }

--- a/src/frontend/src/players/parsers/types.ts
+++ b/src/frontend/src/players/parsers/types.ts
@@ -1,0 +1,14 @@
+type OutputParserResponse = {
+  initSegment: Buffer | undefined
+  data: Buffer
+  canSend: boolean
+}
+
+interface IOutputParser {
+  parse(chunk: Buffer): OutputParserResponse
+}
+
+export {
+  IOutputParser,
+  OutputParserResponse,
+}

--- a/src/frontend/src/players/parsers/types.ts
+++ b/src/frontend/src/players/parsers/types.ts
@@ -1,7 +1,6 @@
 type OutputParserResponse = {
-  initSegment: Buffer | undefined
+  initSegment?: Buffer
   data: Buffer
-  canSend: boolean
 }
 
 interface IOutputParser {

--- a/src/frontend/src/players/pipelines/ffmpegWrapper.ts
+++ b/src/frontend/src/players/pipelines/ffmpegWrapper.ts
@@ -22,7 +22,7 @@ class FfmpegWrapper implements IPipelineTail {
     this.streamer = new IpcStreamer(store.get('streamer'))
   }
 
-  initPipeline(pipeline: PlayingPipeline): void {
+  private initPipeline(pipeline: PlayingPipeline): void {
     pipeline.onEnterState(PlayingPipelineStates.ERROR, () => {
       const error = pipeline.lastError
 

--- a/src/frontend/src/players/pipelines/ffmpegWrapper.ts
+++ b/src/frontend/src/players/pipelines/ffmpegWrapper.ts
@@ -6,20 +6,22 @@ import { PlayerError, PlayerErrors } from '../playerError'
 import { IPipelineTail, PipelinePlayOptions } from '../../interfaces/playerPipeline'
 import { getLogger } from '../../logging/loggers'
 import { PlayingPipeline, PlayingPipelineStates } from './ffmpegPlayingPipeline'
+import { IStreamerConfig } from '../../interfaces/ipcStreamerConfig'
 
 class FfmpegWrapper implements IPipelineTail {
   private id = `${Date.now()}-${Math.floor(1000 * Math.random())}`
   private logger = getLogger(`FfmpegWrapper [${this.id}]`)
-  private streamer: IpcStreamer
+  private streamer = new IpcStreamer()
+  private readonly streamerConfig: IStreamerConfig
   private currentPipeline?: PlayingPipeline
-  private playTimeout?: number
+  private playTimeout?: NodeJS.Timer
 
   set sender(sender: WebContents) {
     this.streamer.sender = sender
   }
 
   constructor(store: Store<IPlayerStore>) {
-    this.streamer = new IpcStreamer(store.get('streamer'))
+    this.streamerConfig = store.get('streamer')
   }
 
   private initPipeline(pipeline: PlayingPipeline): void {
@@ -64,7 +66,7 @@ class FfmpegWrapper implements IPipelineTail {
 
   play(options: PipelinePlayOptions): void {
     this.clear()
-    this.initPipeline(new PlayingPipeline(this.streamer, options))
+    this.initPipeline(new PlayingPipeline(this.streamer, this.streamerConfig, options))
   }
 
   replay(newProps: Partial<PipelinePlayOptions> = {}): void {

--- a/src/frontend/src/players/types.ts
+++ b/src/frontend/src/players/types.ts
@@ -1,0 +1,22 @@
+import type Ffmpeg from '@taktik/fluent-ffmpeg'
+import type { Readable } from 'stream'
+import type { IOutputParser } from './parsers/types'
+import type { PlayerError } from './playerError'
+
+type FfmpegCommandResponse = {
+    command: Ffmpeg.FfmpegCommand
+    parser?: IOutputParser
+}
+
+type FfmpegPipelinesParams = {
+    input: Readable,
+    audioPid?: number,
+    subtitlesPid?: number,
+    deinterlace?: boolean,
+    errorHandler(error: PlayerError): void,
+  }
+
+export type {
+    FfmpegCommandResponse,
+    FfmpegPipelinesParams,
+}

--- a/src/frontend/src/players/types.ts
+++ b/src/frontend/src/players/types.ts
@@ -1,22 +1,29 @@
-import type Ffmpeg from '@taktik/fluent-ffmpeg'
-import type { Readable } from 'stream'
-import type { IOutputParser } from './parsers/types'
+import type { Readable, Writable } from 'stream'
+import type { IStreamerConfig } from '../interfaces/ipcStreamerConfig'
+import type FfmpegParser from './parsers/abstract'
 import type { PlayerError } from './playerError'
 
-type FfmpegCommandResponse = {
-    command: Ffmpeg.FfmpegCommand
-    parser?: IOutputParser
+type FfmpegParserConstructor = new (config: IStreamerConfig) => FfmpegParser
+
+interface IFfmpegCommandWrapper {
+  pipe<T extends Writable>(stream: T, options?: { end?: boolean }): T
+  unpipe<T extends Writable>(stream: T): this
+  kill(): void
 }
 
+type FfmpegCommandBuilder = (parserConfig: IStreamerConfig) => IFfmpegCommandWrapper
+
 type FfmpegPipelinesParams = {
-    input: Readable,
-    audioPid?: number,
-    subtitlesPid?: number,
-    deinterlace?: boolean,
-    errorHandler(error: PlayerError): void,
-  }
+  input: Readable,
+  audioPid?: number,
+  subtitlesPid?: number,
+  deinterlace?: boolean,
+  errorHandler(error: PlayerError): void,
+}
 
 export type {
-    FfmpegCommandResponse,
-    FfmpegPipelinesParams,
+  FfmpegCommandBuilder,
+  FfmpegParserConstructor,
+  FfmpegPipelinesParams,
+  IFfmpegCommandWrapper,
 }

--- a/src/keyboard/keyboardController.ts
+++ b/src/keyboard/keyboardController.ts
@@ -128,7 +128,7 @@ class Keyboard {
       parent.on('close', callback)
       this.parentCloseCallback = { parent, callback }
     }
-    this.keyboardWindow.setParentWindow(parent)
+    this.keyboardWindow?.setParentWindow(parent)
   }
 }
 


### PR DESCRIPTION
Extract mp4 parsing from ipcStreamer. Choose parser depending on the type of ffmpeg's output:
- for radios (mp3): send data at a specified interval
- for tv (mp4): send data whenever a "moof"/"mdat" segment is complete