### PR TITLE
Avoid cb invocation in BUBBLE_PHASE => Avoid not INPUT click cb call

### DIFF
--- a/src/frontend/preloads/exportNode.ts
+++ b/src/frontend/preloads/exportNode.ts
@@ -83,7 +83,7 @@ function onClick(event: Event) {
 
 window.addEventListener('focus', openKeyboard, true)
 window.addEventListener('blur', closeKeyboard, true)
-window.addEventListener('click', onClick)
+window.addEventListener('click', onClick, true)
 window.addEventListener('keydown', handleHiddenMenuCode, true)
 
 process.once('loaded', () => {


### PR DESCRIPTION
If we allow the click event callback to be invoked during the event BUBBLE_PHASE, we end up with an outer and none INPUT DOM target click callback. This leads to a CLOSE VirtualKeyboard CLOSE request. 

By avoiding the BUBBLE_PHASE callback invocation, the event target will be the INPUT if the click occurs on the INPUT DOM element. 

That way, both FOCUS and CLICK events will have the INPUT DOM element as target when clicking on the INPUT and thus both callback will request to OPEN the virtual keyboard.